### PR TITLE
Fixed issue where pagination didnt show all or 4 pages

### DIFF
--- a/source/js/algolia-index-js-searchpage.js
+++ b/source/js/algolia-index-js-searchpage.js
@@ -132,7 +132,7 @@ const renderPagination = (renderOptions, isFirstRender) => {
   const container = document.querySelector('#pagination');
   let paginationHtml = algoliaSearchComponents["pagination-item"].html;
   let paginationIcon = algoliaSearchComponents["pagination-item-icon"].html;
-  let from = currentRefinement < 2 ? 0 : 1;
+  let from = currentRefinement < 2 || pages.length < 5 ? 0 : 1;
   
     container.innerHTML = `
       ${!isFirstPage


### PR DESCRIPTION
Fixed error where the pagination (if less than 5 pages) did not show 4 pages unless user scrolled through them