### PR TITLE
feat: Add `AlgoliaIndex/ShowHitSubheading` filter

### DIFF
--- a/source/js/algolia-index-js-searchpage.js
+++ b/source/js/algolia-index-js-searchpage.js
@@ -229,7 +229,7 @@ document.addEventListener('DOMContentLoaded', function() {
           return htmlString
           .replaceAll("{ALGOLIA_JS_HIT_ID}", hit.uuid)
           .replaceAll("{ALGOLIA_JS_HIT_HEADING}", decodeHtml(hit._highlightResult['post_title'].value))
-          .replaceAll("{ALGOLIA_JS_HIT_SUBHEADING}", hit.origin_site)
+          .replaceAll("{ALGOLIA_JS_HIT_SUBHEADING}", algoliaSearchData.showHitSubheading ? hit.origin_site : '')
           .replaceAll("{ALGOLIA_JS_HIT_EXCERPT}", decodeHtml(hit._highlightResult['post_excerpt'].value))
           .replaceAll("{ALGOLIA_JS_HIT_IMAGE}", hit.thumbnail.replaceAll("/wp/", "/"))
           .replaceAll("{ALGOLIA_JS_HIT_LINK}", hit.permalink);

--- a/source/php/App.php
+++ b/source/php/App.php
@@ -78,6 +78,7 @@ class App
             'searchQuery' => get_search_query(),
             'searchAsYouType' => apply_filters('AlgoliaIndex/SearchAsYouType', true),
             'clientConfig' => apply_filters('AlgoliaIndex/ClientConfig', []),
+            'showHitSubheading' => apply_filters('AlgoliaIndex/ShowHitSubheading', true),
         ]);
 
         //UI settings


### PR DESCRIPTION
Allows the site name to be removed from search results for sites with single index. Defaults to `true`